### PR TITLE
trimfeedstart doesn't update npoints

### DIFF
--- a/processes/trimfeedstart.php
+++ b/processes/trimfeedstart.php
@@ -29,7 +29,7 @@ function trimfeedstart($dir,$processitem)
     }
 
     if (!$if = @fopen($dir.$feedid.".dat", 'rb')) {
-        echo "ERROR: could not open $dir $feedid.dat\n";
+        echo "ERROR: could not open $dir$feedid.dat\n";
         return false;
     }
     

--- a/processes/trimfeedstart.php
+++ b/processes/trimfeedstart.php
@@ -52,6 +52,7 @@ function trimfeedstart($dir,$processitem)
     fclose($of);
     
     $meta->start_time = $trimtime;
+    $meta->npoints = $length;
     createmeta($dir,$feedid,$meta);
     
     return true;


### PR DESCRIPTION
Fixes #3 

By not updating npoints in the metadata, new data added to the feed is offset into the future.  