### PR TITLE
adapt model and shell script so they also work in container

### DIFF
--- a/postprocess-module/postprocess_model.php
+++ b/postprocess-module/postprocess_model.php
@@ -298,6 +298,9 @@ class PostProcess
     }
 
     public function check_service_runner() {
+        if (file_exists("/.dockerenv")) {
+            return true;
+        }
         $service_running = false;
         @exec("systemctl show service-runner | grep State", $output);
         foreach ($output as $line) {

--- a/postprocess.sh
+++ b/postprocess.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-sudo php $DIR/postprocess_run.php
+if [ -f "/.dockerenv" ]; then
+    php $DIR/postprocess_run.php
+else
+    sudo php $DIR/postprocess_run.php
+fi


### PR DESCRIPTION
if the /.dockerenv file exists, you are in a container and so : 
- tests for service are different, in the standalone container, service runner always exists, so we can return true
- you cannot use sudo in shell script